### PR TITLE
Compile with closure compiler and gzip output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ Estuary.db
 bin
 .stack-work/*
 .stack-work
+.stack-work-production/
 static/
 .DS_Store
 *~

--- a/EstuaryServer/EstuaryServer.cabal
+++ b/EstuaryServer/EstuaryServer.cabal
@@ -17,6 +17,6 @@ executable EstuaryServer
   ghc-options:       -threaded
   main-is:           EstuaryServer.hs
   build-depends:     base, containers, text, tidal, hosc, json, websockets,
-                     wai, warp, wai-websockets, wai-app-static, parsec, parsec-numbers,
+                     wai, warp, wai-websockets, wai-app-static, wai-extra, parsec, parsec-numbers,
                      time, sqlite-simple
   default-language:  Haskell2010

--- a/static/index.html.template
+++ b/static/index.html.template
@@ -2,9 +2,11 @@
 <html>
   <head>
     <link href="style.css" rel="stylesheet" type="text/css"/>
+#ifndef PRODUCTION
     <script language="javascript" src="rts.js"></script>
     <script language="javascript" src="lib.js"></script>
     <script language="javascript" src="out.js"></script>
+#endif
     <script language="javascript" src="EstuaryProtocol.js"></script>
     <script language="javascript" src="SuperDirt.js"></script>
     <script language="javascript" src="WebDirt/WebDirt.js"></script>
@@ -14,7 +16,11 @@
 
 function downloadJS() {
   var element4 = document.createElement("script");
+#ifdef PRODUCTION
+  element4.setAttribute('src', "all.min.js");
+#else
   element4.setAttribute('src', "runmain.js");
+#endif
   element4.defer;
   document.head.appendChild(element4);
   console.log("elements added");


### PR DESCRIPTION
Add the Makefile targets for building a production release of the project. This includes using the [google-closure-compiler](https://www.npmjs.com/package/google-closure-compiler) to minify and gzip to compress.

This also includes a small change in which the `index.html` is generated from `index.html.template` by running it through the c preprocessor to include the proper scripts based on the environment.

Note that in order to properly resolve external names from supplementary scripts (like `EstuaryProtocol.js`) they must be included in the externs.

The result of the compression as of this PR was an original `all.js` of ~13MB compressed to ~4.5MB (and 803KB gzipped).