### PR TITLE
Fix image flex issue on firefox

### DIFF
--- a/static/classic.css
+++ b/static/classic.css
@@ -96,22 +96,27 @@ select {
 
 .splash-margin {
 	min-width: 50%;
-
 	box-sizing: border-box;
 	padding: 0.4em;
 }
 
 .splash-panel {
 	font-family: estuaryFont;
-  border: 0.25em solid;
-  border-radius: 4px;
-  padding: 0.5em;
-  text-align: center;
-  height: 100%;
-  box-sizing: border-box;
-  max-height: 16em;
-  display: flex;
-  flex-direction: column;
+	border: 0.25em solid;
+	border-radius: 4px;
+	padding: 0.5em;
+	text-align: center;
+	height: 100%;
+	box-sizing: border-box;
+	max-height: 16em;
+	display: flex;
+	flex-direction: column;
+}
+
+.splash-panel > img {
+	/* A trick to get the images to behave in firefox as they do in chrome, they "flex" to determine the size */
+	min-width: 0;
+	min-height: 0;
 }
 
 .splash-title {


### PR DESCRIPTION
As per a suggestion in https://github.com/philipwalton/flexbugs/issues/184#issue-188113778, setting the `min-width: 0` and `min-height: 0` causes firefox to properly stretch the `img` to fit the container.