### PR TITLE
Interaction test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ installClient: buildClient
 
 prodInstallClient: # make prodBuildClient first!
 	rm -rf ./Estuary.jsexe
-	cp -Rf $(PRODUCTION_CLIENT_INSTALL_DIR) .
+	cp -Rf $(PRODUCTION_CLIENT_INSTALL_DIR) Estuary.jsexe
 	cp -Rf static/* Estuary.jsexe
 	$(CLIENT_GCC_PREPROCESSOR) ../Estuary.jsexe/index.html.template -DPRODUCTION -o ../Estuary.jsexe/index.html
 	rm -rf Estuary.jsexe/runmain.js
@@ -48,6 +48,12 @@ prodInstallClient: # make prodBuildClient first!
 	rm -rf Estuary.jsexe/all.js
 	rm -rf Estuary.jsexe/out.stats
 	rm -rf Estuary.jsexe/index.html.template
+
+installInteractionTestClient:
+	$(STACK_CLIENT) build estuary:exe:interaction-test
+	cp -Rf $$($(STACK_CLIENT) path --local-install-root)/bin/interaction-test.jsexe/* Estuary.jsexe
+	cp -Rf static/* Estuary.jsexe
+	$(CLIENT_GCC_PREPROCESSOR) ../Estuary.jsexe/index.html.template -o ../Estuary.jsexe/index.html
 
 installServer: buildServer
 	mkdir -p EstuaryServer

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ installClient: buildClient
 
 prodInstallClient: # make prodBuildClient first!
 	rm -rf ./Estuary.jsexe
-	cp -Rf $(PRODUCTION_CLIENT_INSTALL_DIR) Estuary.jsexe
+	cp -Rf $(PRODUCTION_CLIENT_INSTALL_DIR) .
 	cp -Rf static/* Estuary.jsexe
 	$(CLIENT_GCC_PREPROCESSOR) ../Estuary.jsexe/index.html.template -DPRODUCTION -o ../Estuary.jsexe/index.html
 	rm -rf Estuary.jsexe/runmain.js

--- a/client/package.yaml
+++ b/client/package.yaml
@@ -67,6 +67,18 @@ executables:
       - hspec
       - async
 
+  interaction-test:
+    main: Interaction.hs
+    source-dirs:
+      - ./test
+    js-sources:
+      - ./test/Estuary/Test/protocol-inspector.js
+    dependencies:
+      - estuary
+      - estuary-common
+      - hspec
+      - async
+
 ################################
 # TESTS
 ################################

--- a/client/test/Estuary/Test/Dom.hs
+++ b/client/test/Estuary/Test/Dom.hs
@@ -1,0 +1,62 @@
+module Estuary.Test.Dom where
+
+import GHCJS.DOM(currentDocument)
+import GHCJS.DOM.Types
+import GHCJS.Marshal
+import GHCJS.Marshal.Pure
+import GHCJS.Nullable
+import GHCJS.Types
+
+import GHCJS.Prim(toJSArray, fromJSArray)
+
+import qualified GHCJS.DOM.HTMLElement as HTMLElement
+
+-- querySelector :: (MonadIO m, IsDocument self, ToJSString selectors) =>
+--   self -> selectors -> m (Maybe Element)
+-- querySelector :: (MonadIO m, IsElement self, ToJSString selectors) =>
+--   self -> selectors -> m (Maybe Element)
+
+maybePFromNullableJSVal :: (PFromJSVal e) => Nullable JSVal -> Maybe e
+maybePFromNullableJSVal = (fmap pFromJSVal) . nullableToMaybe
+
+findMatchingSelectorInDocument :: (ToJSString s, PFromJSVal e) => s -> IO (Maybe e)
+findMatchingSelectorInDocument query =
+  fmap maybePFromNullableJSVal $ 
+    js_docQuerySelector (toJSString query)
+
+findMatchingSelector :: (IsElement c, ToJSString s, PFromJSVal e) => c -> s -> IO (Maybe e)
+findMatchingSelector container query = 
+  fmap maybePFromNullableJSVal $ 
+    js_querySelector (pToJSVal $ toElement container) (toJSString query)
+
+findAllMatchingSelectorInDocument :: (ToJSString s, FromJSVal e) => s -> IO ([e])
+findAllMatchingSelectorInDocument query =
+  js_docQuerySelectorAll (toJSString query) >>= fromJSValUncheckedListOf
+
+findAllMatchingSelector :: (IsElement c, ToJSString s, FromJSVal e) => c -> s -> IO ([e])
+findAllMatchingSelector container query = 
+  js_querySelectorAll (pToJSVal $ toElement container) (toJSString query)  >>= fromJSValUncheckedListOf
+
+
+click :: (IsHTMLElement e) => e -> IO ()
+click =  HTMLElement.click
+
+------------------------------------------
+-- JS FFI
+------------------------------------------
+
+foreign import javascript safe
+  "document.querySelector($1)"
+  js_docQuerySelector :: JSString -> IO (Nullable JSVal)
+
+foreign import javascript safe
+  "$1.querySelector($2)"
+  js_querySelector :: JSVal -> JSString -> IO (Nullable JSVal)
+
+foreign import javascript safe
+  "Array.from(document.querySelector($1))"
+  js_docQuerySelectorAll :: JSString -> IO (JSVal)
+
+foreign import javascript safe
+  "Array.from($1.querySelector($2))"
+  js_querySelectorAll :: JSVal -> JSString -> IO (JSVal)

--- a/client/test/Estuary/Test/Estuary.hs
+++ b/client/test/Estuary/Test/Estuary.hs
@@ -79,33 +79,25 @@ controllableEstuaryWidget pageId ctxVar renderInfoVar protocol = divClass "estua
   updateContext ctxVar ctx
   performHint (webDirt initialCtx) hints
 
-silentEstuaryWithInitialPage :: Navigation -> IO EstuaryProtocolObject
-silentEstuaryWithInitialPage pageId = do
+silentEstuaryWithInitialPage :: EstuaryProtocolObject -> Navigation -> IO ()
+silentEstuaryWithInitialPage protocol pageId = do
   initialCtx <- initCtx
   ctxVar <- newMVar $ initialCtx
 
   renderInfoVar <- newMVar $ emptyRenderInfo
   forkRenderThread ctxVar renderInfoVar
-
-  protocol <- estuaryProtocol
   
   renderSync_ $ 
     controllableEstuaryWidget pageId ctxVar renderInfoVar protocol
 
-  return protocol
-
-silentEstuary :: IO EstuaryProtocolObject
-silentEstuary = do
+silentEstuary :: EstuaryProtocolObject -> IO ()
+silentEstuary protocol = do
   ic <- initCtx
   c <- newMVar $ ic
   ri <- newMVar $ emptyRenderInfo
   forkRenderThread c ri
-
-  protocol <- estuaryProtocol
   
   renderSync_ $ estuaryWidget c ri protocol
-
-  return protocol
 
 initCtx :: IO Context
 initCtx = do

--- a/client/test/Estuary/Test/Estuary.hs
+++ b/client/test/Estuary/Test/Estuary.hs
@@ -1,0 +1,124 @@
+{-# LANGUAGE RecursiveDo #-}
+module Estuary.Test.Estuary where
+
+import Reflex.Dom
+import Data.Time
+
+import Control.Concurrent.MVar
+import Control.Monad (liftM)
+import Control.Monad.IO.Class (liftIO)
+
+import Estuary.WebDirt.WebDirt
+import Estuary.WebDirt.SuperDirt
+
+import Estuary.Protocol.Foreign
+
+import Estuary.Widgets.Estuary
+import Estuary.Widgets.Terminal
+import Estuary.Widgets.Navigation
+import Estuary.Widgets.WebSocket
+
+import Estuary.Types.Request
+import Estuary.Types.Response
+import Estuary.Types.Context
+import Estuary.Types.Hint
+import Estuary.Types.View
+import Estuary.Types.Definition
+import Estuary.Types.Terminal
+import Estuary.Types.Tempo
+
+import Estuary.WebDirt.SampleEngine
+import Estuary.RenderInfo
+import Estuary.RenderState
+import Estuary.Renderer
+
+import Estuary.Test.Reflex
+
+-- estuaryWidget -> deltasUp is an event for web socket events
+--  they are passed to the EstuaryProtocolObject
+--  alternateProtocol in WebSocket serializes the Requests
+
+controllableNavigationWidget :: MonadWidget t m => Navigation -> Dynamic t Context -> Dynamic t RenderInfo -> Event t Command -> Event t [Response] -> m (Dynamic t DefinitionMap, Event t Request, Event t Hint, Event t Tempo)
+controllableNavigationWidget pageId ctx renderInfo commands wsDown = mdo
+  let initialPage = page ctx renderInfo commands wsDown pageId
+  let rebuild = fmap (page ctx renderInfo commands wsDown) navEvents
+  w <- widgetHold initialPage rebuild
+  values <- liftM joinDyn $ mapDyn (\(x,_,_,_,_)->x) w
+  wsUp <- liftM switchPromptlyDyn $ mapDyn (\(_,x,_,_,_)->x) w
+  hints <- liftM switchPromptlyDyn $ mapDyn (\(_,_,x,_,_)->x) w
+  navEvents <- liftM switchPromptlyDyn $ mapDyn (\(_,_,_,x,_)->x) w
+  tempoEvents <- liftM switchPromptlyDyn $ mapDyn (\(_,_,_,_,x)->x) w
+  return (values, wsUp, hints, tempoEvents)
+
+controllableEstuaryWidget :: MonadWidget t m => Navigation -> MVar Context -> MVar RenderInfo -> EstuaryProtocolObject -> m ()
+controllableEstuaryWidget pageId ctxVar renderInfoVar protocol = divClass "estuary" $ mdo
+  renderInfo <- pollRenderInfoChanges renderInfoVar
+
+  headerChanges <- header ctx renderInfo
+
+  (values, deltasUp, hints, tempoChanges) <- divClass "page" $
+    controllableNavigationWidget pageId ctx renderInfo commands deltasDown'
+
+  commands <- divClass "chat" $ 
+    terminalWidget ctx deltasUp deltasDown'
+
+  (deltasDown, wsStatus) <- alternateWebSocket protocol deltasUp
+
+  let definitionChanges = fmap setDefinitions $ updated values
+  let deltasDown' = ffilter (not . Prelude.null) deltasDown
+  let ccChange = fmap setClientCount $ fmapMaybe justServerClientCount deltasDown'
+  let tempoChanges' = fmap (\t x -> x { tempo = t }) tempoChanges
+  let contextChanges = mergeWith (.) [definitionChanges, headerChanges, ccChange, tempoChanges']
+  
+  initialCtx <- liftIO $ readMVar ctxVar
+  ctx <- foldDyn ($) initialCtx contextChanges -- Dynamic t Context
+
+  themeChangeEv <- fmap updated $ mapDyn theme ctx -- Event t String
+  
+  changeTheme themeChangeEv
+  updateContext ctxVar ctx
+  performHint (webDirt initialCtx) hints
+
+silentEstuaryWithInitialPage :: Navigation -> IO EstuaryProtocolObject
+silentEstuaryWithInitialPage pageId = do
+  initialCtx <- initCtx
+  ctxVar <- newMVar $ initialCtx
+
+  renderInfoVar <- newMVar $ emptyRenderInfo
+  forkRenderThread ctxVar renderInfoVar
+
+  protocol <- estuaryProtocol
+  
+  renderSync_ $ 
+    controllableEstuaryWidget pageId ctxVar renderInfoVar protocol
+
+  return protocol
+
+silentEstuary :: IO EstuaryProtocolObject
+silentEstuary = do
+  ic <- initCtx
+  c <- newMVar $ ic
+  ri <- newMVar $ emptyRenderInfo
+  forkRenderThread c ri
+
+  protocol <- estuaryProtocol
+  
+  renderSync_ $ estuaryWidget c ri protocol
+
+  return protocol
+
+initCtx :: IO Context
+initCtx = do
+  now <- Data.Time.getCurrentTime
+  let ctx = initialContext now js_nullWebDirt js_nullSuperDirt
+  return $ ctx {
+    webDirtOn = False
+  }
+
+foreign import javascript safe
+  "null"
+  js_nullWebDirt :: WebDirt
+
+foreign import javascript safe
+  "null"
+  js_nullSuperDirt :: SuperDirt

--- a/client/test/Estuary/Test/Protocol.hs
+++ b/client/test/Estuary/Test/Protocol.hs
@@ -1,0 +1,152 @@
+module Estuary.Test.Protocol where
+
+import Control.Concurrent
+import Control.Concurrent.Async
+import Control.Concurrent.Chan
+import Control.Concurrent.MVar
+import Control.Monad
+
+import Test.Hspec
+
+import Text.JSON
+
+import Estuary.Protocol.Foreign
+
+import Estuary.Types.Request
+import Estuary.Types.Response
+import Estuary.Types.Sited
+import Estuary.Types.EnsembleRequest
+import Estuary.Types.EnsembleResponse
+
+import GHCJS.DOM.Types
+import GHCJS.Marshal
+import GHCJS.Marshal.Pure
+import GHCJS.Types
+import GHCJS.Foreign.Callback
+
+data MessageMatchStatus
+  = Matches
+  | AlmostMatches
+  | DoesNotMatch
+
+instance Monoid MessageMatchStatus where
+  mempty = Matches
+  Matches `mappend` _ = Matches
+  _ `mappend` Matches = Matches
+  AlmostMatches `mappend` _ = AlmostMatches
+  _ `mappend` AlmostMatches = AlmostMatches
+  DoesNotMatch `mappend` _ = DoesNotMatch
+
+type MatchTest a = a -> MessageMatchStatus
+
+emptyMatchTest :: MatchTest a
+emptyMatchTest _ = DoesNotMatch
+
+data MessageExpectation a r = MessageExpectation {
+  messageTimeout :: Maybe Int,
+  matchTest :: MatchTest a,
+  supplement :: r
+}
+
+mergeMessageExpectations :: (s1 -> s2 -> s3) -> MessageExpectation a s1 -> MessageExpectation a s2 -> MessageExpectation a s3
+mergeMessageExpectations merger (MessageExpectation time1 test1 s1) (MessageExpectation time2 test2 s2) =
+  MessageExpectation {
+    messageTimeout = case time2 of { Nothing -> time1; _ -> time2 },
+    matchTest = \a -> (test1 a) `mappend` (test2 a),
+    supplement = merger s1 s2
+  }
+
+instance Functor (MessageExpectation a) where
+  fmap f expectation = expectation { supplement = f (supplement expectation) }
+
+instance Applicative (MessageExpectation a) where
+  pure x = emptyMessageExpectation { supplement = x }
+  (<*>) = mergeMessageExpectations ($)
+
+instance Monad (MessageExpectation a) where
+  expectation >>= f = mergeMessageExpectations (const id) expectation (f (supplement expectation))
+
+emptyMessageExpectation :: MessageExpectation a ()
+emptyMessageExpectation = MessageExpectation {
+  messageTimeout = Nothing,
+  matchTest = emptyMatchTest,
+  supplement = ()
+}
+
+withinMillis :: Int -> MessageExpectation a ()
+withinMillis t = emptyMessageExpectation { messageTimeout = Just t }
+
+toMatch :: MatchTest a -> MessageExpectation a ()
+toMatch test = emptyMessageExpectation { matchTest = test }
+
+expectRequest :: Chan (Maybe Request) -> MessageExpectation Request a -> IO ()
+expectRequest reqChan e@(MessageExpectation Nothing _ _) = 
+  expectRequest reqChan $ e { messageTimeout = Just 1000 }
+expectRequest reqChan (MessageExpectation (Just ms) test _) = do
+  almostReqsVar <- newMVar []
+
+  result <- race (threadDelay $ ms * 1000) (checkRequest reqChan test almostReqsVar)
+  case result of
+    Right _ -> return ()
+    Left _ -> do
+      almostReqs <- readMVar almostReqsVar
+      let desc = case almostReqs of
+            [] -> "    No similar messages produced."
+            almostMatches -> foldr (\l r -> l ++ "\n" ++ r) "" $ fmap (\r -> "    - " ++ encode r) almostMatches
+      expectationFailure $ "Message was not produced within " ++ show ms ++ "ms." ++ desc
+
+checkRequest :: Chan (Maybe Request) -> MatchTest Request -> MVar [Request] -> IO Request
+checkRequest chan test almost = do
+  mReq <- readChan chan
+  case mReq of
+    Nothing -> checkRequest chan test almost
+    Just req -> case test req of
+      Matches -> return req
+      AlmostMatches -> do
+        modifyMVar_ almost $ return . ((:) req)
+        checkRequest chan test almost
+      DoesNotMatch -> checkRequest chan test almost
+
+
+
+attachMsgRecvProtocolInspector :: EstuaryProtocolObject -> (Maybe Response -> IO ()) -> IO ()
+attachMsgRecvProtocolInspector (EstuaryProtocolObject protocol) inspect = do
+  cb <- asyncCallback1 $ \nJsSerResp -> 
+    inspect $ do -- in Maybe 
+      jsSerResp <- mfilter isNull (pure nJsSerResp)
+      serResp <- pFromJSVal jsSerResp
+      case decode serResp of
+        Ok resp -> return resp
+        Error _ -> Nothing
+  js_attachOnRecvMsg protocol cb
+  releaseCallback cb
+
+attachSendMsgProtocolInspector :: EstuaryProtocolObject -> (Maybe Request -> IO ()) -> IO ()
+attachSendMsgProtocolInspector (EstuaryProtocolObject protocol) inspect = do
+  cb <- asyncCallback1 $ \nJsSerReq -> 
+    inspect $ do -- in Maybe 
+      jsSerReq <- mfilter isNull (pure nJsSerReq)
+      serResp <- pFromJSVal jsSerReq
+      case decode serResp of
+        Ok resp -> return resp
+        Error _ -> Nothing
+  js_attachOnSendMsg protocol cb
+  releaseCallback cb
+
+foreign import javascript safe
+  "estuaryProtocolInspector.onRecvMsg($1, $2)"
+  js_attachOnRecvMsg:: JSVal -> Callback (JSVal -> IO ()) -> IO ()
+
+foreign import javascript safe
+  "estuaryProtocolInspector.onSendMsg($1, $2)"
+  js_attachOnSendMsg:: JSVal -> Callback (JSVal -> IO ()) -> IO ()
+
+attachProtocolInspectors :: EstuaryProtocolObject -> IO (Chan (Maybe Request), Chan (Maybe Response))
+attachProtocolInspectors protocol = do
+  reqChan <- newChan
+  respChan <- newChan
+
+  attachSendMsgProtocolInspector protocol $ writeChan reqChan
+  attachMsgRecvProtocolInspector protocol $ writeChan respChan
+
+  return (reqChan, respChan)

--- a/client/test/Estuary/Test/Reflex.hs
+++ b/client/test/Estuary/Test/Reflex.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE TypeFamilies #-}
+module Estuary.Test.Reflex where
+
+import Control.Concurrent.MVar
+import Control.Concurrent.Async
+import Control.Monad.IO.Class
+
+import Data.Map
+
+import GHCJS.DOM.Types (Element, HTMLDivElement, castToHTMLDivElement, fromJSString)
+
+import Reflex.Dom hiding (link)
+import Reflex.Dynamic
+import Reflex.Host.Class (HostFrame)
+
+-- The type of widget that `mainWidget` can render.
+type SpiderM = Widget Spider (Gui Spider (WithWebView SpiderHost) (HostFrame Spider))
+
+-- renderSync renders the widget, waits for it to mount, and returns the container
+-- element it was mounted in.
+renderSync :: (MonadWidget t m, m ~ SpiderM) => m a -> IO (HTMLDivElement)
+renderSync widget = do
+  resultContainer <- newEmptyMVar
+  finishedRender <- async $ takeMVar resultContainer
+  link finishedRender -- any exceptions should be thrown here
+
+  mainWidget $ do
+    (e, _) <- elAttr' "div" (fromList [("id", "test-container")]) widget
+
+    let containerEl = castToHTMLDivElement $ _el_element e
+    postBuildEv <- getPostBuild
+    performEvent_ $ ffor postBuildEv $ \_ -> liftIO $
+      putMVar resultContainer containerEl
+
+  wait finishedRender
+
+-- renderSync_ renders the widget and waits for it to mount.
+renderSync_ :: (MonadWidget t m, m ~ SpiderM) => m a -> IO ()
+renderSync_ widget = do
+  resultContainer <- newEmptyMVar
+  finishedRender <- async $ takeMVar resultContainer
+  link finishedRender -- any exceptions should be thrown here
+
+  mainWidget $ do
+    elAttr' "div" (fromList [("id", "test-container")]) widget
+
+    postBuildEv <- getPostBuild
+    performEvent_ $ ffor postBuildEv $ \_ -> liftIO $
+      putMVar resultContainer ()
+
+  wait finishedRender
+
+renderSyncWithEvent :: (MonadWidget t m, m ~ SpiderM) => m a -> IO ()
+renderSyncWithEvent widget = do
+  resultContainer <- newEmptyMVar
+  finishedRender <- async $ takeMVar resultContainer
+  link finishedRender -- any exceptions should be thrown here
+
+  mainWidget $ do
+    elAttr' "div" (fromList [("id", "test-container")]) widget
+
+    postBuildEv <- getPostBuild
+    performEvent_ $ ffor postBuildEv $ \_ -> liftIO $
+      putMVar resultContainer ()
+
+  wait finishedRender

--- a/client/test/Estuary/Test/protocol-inspector.js
+++ b/client/test/Estuary/Test/protocol-inspector.js
@@ -1,0 +1,43 @@
+var estuaryProtocolInspector = (function () {
+  function onRecvMsg(protocol, callback) {
+    var oldOnMessage = protocol.onMessage;
+    protocol.onMessage = function (/*...arguments*/) {
+      var oldLen = protocol.responses.length;
+
+      var result = oldOnMessage.apply(protocol, arguments);
+      
+      var newLen = protocol.responses.length;
+      if (oldLen !== newLen) {
+        // The parse succeeded and a response was added to
+        // the end of the responses array.
+        var response = protocol.responses[newLen - 1];
+
+        // Call the callback with the serialized response
+        callback(JSON.stringify(response));
+      } else {
+        // Parse failed, invoke with null to signal bad message received
+        callback(null);
+      }
+
+      return result;
+    };
+  }
+
+  function onSendMsg(protocol, callback) {
+    var oldSend = protocol.send;
+    protocol.send = function (/*...arguments*/) {
+      var data = arguments[0];
+      try {
+        callback(JSON.stringify(data));
+      } catch (e) {
+        callback(null);
+      }
+      return oldOnMessage.apply(protocol, arguments);
+    };
+  }
+
+  return {
+    onRecvMsg: onRecvMsg,
+    onSendMsg: onSendMsg
+  }
+})();

--- a/client/test/Estuary/Test/protocol-inspector.js
+++ b/client/test/Estuary/Test/protocol-inspector.js
@@ -5,7 +5,7 @@ var estuaryProtocolInspector = (function () {
       var oldLen = protocol.responses.length;
 
       var result = oldOnMessage.apply(protocol, arguments);
-      
+
       var newLen = protocol.responses.length;
       if (oldLen !== newLen) {
         // The parse succeeded and a response was added to
@@ -28,16 +28,28 @@ var estuaryProtocolInspector = (function () {
     protocol.send = function (/*...arguments*/) {
       var data = arguments[0];
       try {
-        callback(JSON.stringify(data));
+        JSON.stringify(data);
+        callback(data);
       } catch (e) {
         callback(null);
       }
-      return oldOnMessage.apply(protocol, arguments);
+      return oldSend.apply(protocol, arguments);
     };
+  }
+
+  function onConnect(protocol, callback) {
+    if (protocol.wsReady)
+      return callback();
+
+    protocol.onReadyStateChange(function (wsReady) {
+      if (wsReady)
+        callback();
+    });
   }
 
   return {
     onRecvMsg: onRecvMsg,
-    onSendMsg: onSendMsg
+    onSendMsg: onSendMsg,
+    onConnect: onConnect
   }
 })();

--- a/client/test/Interaction.hs
+++ b/client/test/Interaction.hs
@@ -1,0 +1,77 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Main(main) where
+
+import Control.Concurrent
+import Control.Concurrent.MVar
+import Control.Concurrent.Async
+import Control.Monad.IO.Class
+
+import Data.Map
+import Data.Maybe
+import Data.Time
+
+import GHCJS.DOM.Types(Element, HTMLElement, HTMLTextAreaElement, castToHTMLElement, fromJSString)
+import qualified GHCJS.DOM.HTMLElement as HTMLElement
+import qualified GHCJS.DOM.HTMLTextAreaElement as HTMLTextAreaElement
+
+import Estuary.RenderInfo
+
+import Estuary.Types.Request
+import Estuary.Types.Response
+import Estuary.Types.EnsembleRequest
+import Estuary.Types.EnsembleResponse
+import Estuary.Types.Context
+import Estuary.Types.Hint
+import Estuary.Types.View
+import Estuary.Types.Definition
+import Estuary.Types.Terminal
+import Estuary.Types.Tempo
+import Estuary.Types.Sited
+import Estuary.Types.Live
+import Estuary.Types.EditOrEval
+import Estuary.Types.TidalParser
+import Estuary.Types.TextNotation
+
+import Estuary.Test.Protocol
+import Estuary.Test.Estuary
+import Estuary.Test.Dom
+
+import Estuary.Widgets.Navigation
+
+import Reflex.Dom hiding (link)
+import Reflex.Dynamic
+
+import Test.Hspec
+
+-- type code -> hit eval -> expect certain network message
+--                       -> expect parse icon
+
+main :: IO ()
+main = hspec $ do
+  describe "clicking the eval button on a minitidal widget" $ do
+    (reqStream, respStream) <- runIO $ do
+      protocol <- silentEstuaryWithInitialPage $ Collaborate "abc"
+      (reqStream, respStream) <- attachProtocolInspectors protocol
+
+      threadDelay $ 1000 * 1000
+
+      Just editor  <- findMatchingSelectorInDocument ".estuary .page .eightMiddleL .textPatternChain:nth-child(2)"
+      Just evalBtn <- findMatchingSelector (editor :: Element) "button"
+      Just txtArea <- findMatchingSelector (editor :: Element) "textarea"
+
+      HTMLTextAreaElement.setValue (txtArea :: HTMLTextAreaElement) $ Just "s \"bd\""
+      HTMLElement.click (evalBtn :: HTMLElement)
+
+      return (reqStream, respStream)
+
+    it "produces an ensemble request for evaluating the text" $ do 
+      expectRequest reqStream $ do
+        withinMillis 1000
+        toMatch $ \case
+          EnsembleRequest (Sited _ (ZoneRequest (Sited _ editOrEval))) -> 
+            case editOrEval of
+              Evaluate (TextProgram (Live (TidalTextNotation MiniTidal, "s \"bd\"") L3)) ->
+                Matches
+              _ -> AlmostMatches
+          _ -> DoesNotMatch


### PR DESCRIPTION
Add a working proof of concept interaction test along with some of the infrastructure for writing similar tests.

Running `make installInteractionTestClient` should build the test executable that must be run with a server and databse that have an `abc` ensemble with the `abc` password. I'm not yet sure how/where to declare these environment dependencies for running tests. The console will contain the hspec output.