### PR TITLE
Fix broken tests and add sample map to context

### DIFF
--- a/client/app/Main.hs
+++ b/client/app/Main.hs
@@ -11,6 +11,7 @@ import Estuary.WebDirt.SuperDirt
 import Estuary.Protocol.Foreign
 import Estuary.Types.Context
 import Estuary.Widgets.Estuary
+import Estuary.Widgets.Navigation(Navigation(..))
 import Estuary.WebDirt.SampleEngine
 import Estuary.RenderInfo
 import Estuary.RenderState
@@ -27,7 +28,7 @@ main = do
   c <- newMVar $ ic
   ri <- newMVar $ emptyRenderInfo
   forkRenderThread c ri
-  mainWidget $ estuaryWidget c ri protocol
+  mainWidget $ estuaryWidget Splash c ri protocol
 
 foreign import javascript safe
   "window.addEventListener('beforeunload', function (e) { e.preventDefault(); e.returnValue = ''; });"

--- a/client/package.yaml
+++ b/client/package.yaml
@@ -68,17 +68,17 @@ executables:
       - hspec
       - async
 
-#  interaction-test:
-#    main: Interaction.hs
-#    source-dirs:
-#      - ./test
-#    js-sources:
-#      - ./test/Estuary/Test/protocol-inspector.js
-#    dependencies:
-#      - estuary
-#      - estuary-common
-#      - hspec
-#      - async
+  interaction-test:
+    main: Interaction.hs
+    source-dirs:
+      - ./test
+    js-sources:
+      - ./test/Estuary/Test/protocol-inspector.js
+    dependencies:
+      - estuary
+      - estuary-common
+      - hspec
+      - async
 
 ################################
 # TESTS

--- a/client/src/Estuary/Reflex/Router.hs
+++ b/client/src/Estuary/Reflex/Router.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE RecursiveDo, ScopedTypeVariables #-}
 
 module Estuary.Reflex.Router(
-  router
+  router,
+  getInitialState
 ) where
 
 import Control.Monad.IO.Class
@@ -30,9 +31,7 @@ import Reflex.Dom
 
 router :: (MonadWidget t m, FromJSVal state, ToJSVal state) => state -> (state -> m (Event t state, a)) -> m (Dynamic t (Event t state, a))
 router def renderPage = mdo
-  state <- liftIO $ getInitialState def
-
-  let initialPage = renderPage state
+  let initialPage = renderPage def
 
   -- Triggered ambiently (back button or otherwise). If the state is null or can't
   -- be decoded, fall back into the initial state.

--- a/client/src/Estuary/Types/Context.hs
+++ b/client/src/Estuary/Types/Context.hs
@@ -5,6 +5,7 @@ import Data.IntMap.Strict
 import Estuary.Tidal.Types
 import Estuary.Types.Language
 import Estuary.Types.Definition
+import Estuary.Types.Samples
 import Estuary.WebDirt.WebDirt
 import Estuary.WebDirt.SuperDirt
 import Estuary.RenderState
@@ -17,6 +18,7 @@ data Context = Context {
   theme :: String,
   tempo :: Tempo,
   definitions :: DefinitionMap,
+  samples :: SampleMap,
   webDirtOn :: Bool,
   superDirtOn :: Bool,
   peakLevels :: [Double],
@@ -33,6 +35,7 @@ initialContext now wd sd = Context {
   theme = "../css-custom/classic.css",
   tempo = Tempo { cps = 0.5, at = now, beat = 0.0 },
   definitions = empty,
+  samples = emptySampleMap,
   webDirtOn = True,
   superDirtOn = False,
   peakLevels = [],
@@ -60,3 +63,6 @@ setClientCount x c = c { clientCount = x }
 
 setDefinitions :: DefinitionMap -> ContextChange
 setDefinitions x c = c { definitions = x }
+
+setSampleMap :: SampleMap -> ContextChange
+setSampleMap x c = c { samples = x}

--- a/client/src/Estuary/Types/Samples.hs
+++ b/client/src/Estuary/Types/Samples.hs
@@ -1,0 +1,77 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving, OverloadedStrings, RecursiveDo #-}
+module Estuary.Types.Samples (
+  SampleMap(..),
+  SampleList,
+  emptySampleMap,
+  loadSampleMapAsync,
+  defaultSampleMapURL
+) where
+
+import GHCJS.DOM.Types(ToJSString(..), FromJSString(..), toJSString, fromJSString)
+import GHCJS.Foreign.Callback
+import GHCJS.Marshal
+import GHCJS.Marshal.Pure
+import GHCJS.Types
+
+import Text.JSON(JSON, JSKey)
+import qualified Text.JSON as JSON
+
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+
+import Data.Sequence(Seq)
+import qualified Data.Sequence as Seq
+import qualified Data.Foldable as Seq(toList)
+
+-- TODO this would be a nice place to use text
+
+newtype SampleMap = SampleMap { unSampleMap :: Map String SampleList }
+  deriving (Show)
+
+type SampleList = Seq String
+
+emptySampleMap :: SampleMap
+emptySampleMap = SampleMap Map.empty
+
+instance (JSON a) => JSON (Seq a) where
+  readJSON jsonVal = do
+    names <- JSON.readJSONs jsonVal
+    return $ Seq.fromList names
+  showJSON seq = JSON.showJSONs $ Seq.toList seq
+
+-- Need newtype so we can override default instance
+instance JSON SampleMap where
+  readJSON jsonVal = do
+    pairs <- JSON.decJSDict "SampleMap" jsonVal
+    return $ SampleMap $ Map.fromList pairs
+  showJSON map = JSON.encJSDict $ Map.toList $ unSampleMap $ map
+
+defaultSampleMapURL :: JSString
+defaultSampleMapURL = "WebDirt/sampleMap.json"
+
+loadSampleMapAsync :: (ToJSString url) => url -> (Maybe SampleMap -> IO ()) -> IO ()
+loadSampleMapAsync url onLoad = do
+  rec cb <- asyncCallback1 $ \mapJs -> do
+        if isNull mapJs || isUndefined mapJs
+          then onLoad Nothing
+          else
+            case JSON.decode $ fromJSString $ pFromJSVal $ mapJs of
+              JSON.Error err -> onLoad Nothing
+              JSON.Ok map -> onLoad $ Just map
+        releaseCallback cb
+  js_loadSamplesAsync (toJSString url) cb
+
+------------------------------------------
+-- JS FFI
+------------------------------------------
+
+-- TODO should this not be connected to webdirt?
+foreign import javascript safe
+  "var xhr = new XMLHttpRequest();                 \n\
+  \xhr.open('GET', $1, true);                      \n\     
+  \xhr.responseType = 'text';                      \n\
+  \xhr.onload  = function() { $2(xhr.response); }; \n\
+  \xhr.onabort = function() { $2(null); };         \n\
+  \xhr.onerror = function() { $2(null); };         \n\
+  \xhr.send();                                      "
+  js_loadSamplesAsync :: JSString -> Callback (JSVal -> IO ()) -> IO ()

--- a/client/src/Estuary/Widgets/Navigation.hs
+++ b/client/src/Estuary/Widgets/Navigation.hs
@@ -52,9 +52,9 @@ data Navigation =
   Collaborate String
   deriving (Generic, FromJSVal, ToJSVal)
 
-navigation :: MonadWidget t m => Dynamic t Context -> Dynamic t RenderInfo -> Event t Command -> Event t [Response] -> m (Dynamic t DefinitionMap, Event t Request, Event t Hint, Event t Tempo)
-navigation ctx renderInfo commands wsDown = do
-  dynPage <- router Splash $ page ctx renderInfo commands wsDown
+navigation :: MonadWidget t m => Navigation -> Dynamic t Context -> Dynamic t RenderInfo -> Event t Command -> Event t [Response] -> m (Dynamic t DefinitionMap, Event t Request, Event t Hint, Event t Tempo)
+navigation initialPage ctx renderInfo commands wsDown = do
+  dynPage <- router initialPage $ page ctx renderInfo commands wsDown
 
   dynPageData <- mapDyn snd dynPage
   dynValues <- liftM joinDyn           $ mapDyn (\(x, _, _, _) -> x) dynPageData

--- a/client/test/Estuary/Test/Dom.hs
+++ b/client/test/Estuary/Test/Dom.hs
@@ -9,6 +9,7 @@ import GHCJS.Types
 
 import GHCJS.Prim(toJSArray, fromJSArray)
 
+import qualified GHCJS.DOM.HTMLInputElement as HTMLInputElement
 import qualified GHCJS.DOM.HTMLElement as HTMLElement
 
 -- querySelector :: (MonadIO m, IsDocument self, ToJSString selectors) =>
@@ -39,7 +40,18 @@ findAllMatchingSelector container query =
 
 
 click :: (IsHTMLElement e) => e -> IO ()
-click =  HTMLElement.click
+click = HTMLElement.click
+
+changeValue :: (IsGObject e) => e -> String -> IO ()
+changeValue e value = do
+  let e' :: HTMLInputElement
+      e' = unsafeCastGObject $ toGObject e
+      
+  HTMLInputElement.setValue e' (Just value)
+  notifyChanged e'
+
+notifyChanged :: (IsEventTarget e) => e -> IO ()
+notifyChanged e = js_dispatchInputEvent (pToJSVal $ toEventTarget e)
 
 ------------------------------------------
 -- JS FFI
@@ -60,3 +72,7 @@ foreign import javascript safe
 foreign import javascript safe
   "Array.from($1.querySelector($2))"
   js_querySelectorAll :: JSVal -> JSString -> IO (JSVal)
+
+foreign import javascript safe
+  "$1.dispatchEvent(new Event('input'))"
+  js_dispatchInputEvent :: JSVal -> IO ()

--- a/client/test/Estuary/Test/Estuary.hs
+++ b/client/test/Estuary/Test/Estuary.hs
@@ -34,9 +34,9 @@ import Estuary.Renderer
 
 import Estuary.Test.Reflex
 
-estuaryWidget -> deltasUp is an event for web socket events
- they are passed to the EstuaryProtocolObject
- alternateProtocol in WebSocket serializes the Requests
+-- estuaryWidget -> deltasUp is an event for web socket events
+--  they are passed to the EstuaryProtocolObject
+--  alternateProtocol in WebSocket serializes the Requests
 
 controllableNavigationWidget :: MonadWidget t m => Navigation -> Dynamic t Context -> Dynamic t RenderInfo -> Event t Command -> Event t [Response] -> m (Dynamic t DefinitionMap, Event t Request, Event t Hint, Event t Tempo)
 controllableNavigationWidget pageId ctx renderInfo commands wsDown = mdo

--- a/client/test/Estuary/Test/Estuary.hs
+++ b/client/test/Estuary/Test/Estuary.hs
@@ -13,6 +13,7 @@ import Estuary.WebDirt.SuperDirt
 
 import Estuary.Protocol.Foreign
 
+import Estuary.WebDirt.SampleEngine
 import Estuary.Widgets.Estuary
 import Estuary.Widgets.Terminal
 import Estuary.Widgets.Navigation
@@ -27,57 +28,12 @@ import Estuary.Types.Definition
 import Estuary.Types.Terminal
 import Estuary.Types.Tempo
 
-import Estuary.WebDirt.SampleEngine
+import Estuary.Reflex.Router
 import Estuary.RenderInfo
 import Estuary.RenderState
 import Estuary.Renderer
 
 import Estuary.Test.Reflex
-
--- estuaryWidget -> deltasUp is an event for web socket events
---  they are passed to the EstuaryProtocolObject
---  alternateProtocol in WebSocket serializes the Requests
-
-controllableNavigationWidget :: MonadWidget t m => Navigation -> Dynamic t Context -> Dynamic t RenderInfo -> Event t Command -> Event t [Response] -> m (Dynamic t DefinitionMap, Event t Request, Event t Hint, Event t Tempo)
-controllableNavigationWidget pageId ctx renderInfo commands wsDown = mdo
-  let initialPage = page ctx renderInfo commands wsDown pageId
-  let rebuild = fmap (page ctx renderInfo commands wsDown) navEvents
-  w <- widgetHold initialPage rebuild
-  values <- liftM joinDyn $ mapDyn (\(x,_,_,_,_)->x) w
-  wsUp <- liftM switchPromptlyDyn $ mapDyn (\(_,x,_,_,_)->x) w
-  hints <- liftM switchPromptlyDyn $ mapDyn (\(_,_,x,_,_)->x) w
-  navEvents <- liftM switchPromptlyDyn $ mapDyn (\(_,_,_,x,_)->x) w
-  tempoEvents <- liftM switchPromptlyDyn $ mapDyn (\(_,_,_,_,x)->x) w
-  return (values, wsUp, hints, tempoEvents)
-
-controllableEstuaryWidget :: MonadWidget t m => Navigation -> MVar Context -> MVar RenderInfo -> EstuaryProtocolObject -> m ()
-controllableEstuaryWidget pageId ctxVar renderInfoVar protocol = divClass "estuary" $ mdo
-  renderInfo <- pollRenderInfoChanges renderInfoVar
-
-  headerChanges <- header ctx renderInfo
-
-  (values, deltasUp, hints, tempoChanges) <- divClass "page" $
-    controllableNavigationWidget pageId ctx renderInfo commands deltasDown'
-
-  commands <- divClass "chat" $
-    terminalWidget ctx deltasUp deltasDown'
-
-  (deltasDown, wsStatus) <- alternateWebSocket protocol deltasUp
-
-  let definitionChanges = fmap setDefinitions $ updated values
-  let deltasDown' = ffilter (not . Prelude.null) deltasDown
-  let ccChange = fmap setClientCount $ fmapMaybe justServerClientCount deltasDown'
-  let tempoChanges' = fmap (\t x -> x { tempo = t }) tempoChanges
-  let contextChanges = mergeWith (.) [definitionChanges, headerChanges, ccChange, tempoChanges']
-
-  initialCtx <- liftIO $ readMVar ctxVar
-  ctx <- foldDyn ($) initialCtx contextChanges -- Dynamic t Context
-
-  themeChangeEv <- fmap updated $ mapDyn theme ctx -- Event t String
-
-  changeTheme themeChangeEv
-  updateContext ctxVar ctx
-  performHint (webDirt initialCtx) hints
 
 silentEstuaryWithInitialPage :: EstuaryProtocolObject -> Navigation -> IO ()
 silentEstuaryWithInitialPage protocol pageId = do
@@ -88,16 +44,10 @@ silentEstuaryWithInitialPage protocol pageId = do
   forkRenderThread ctxVar renderInfoVar
 
   renderSync_ $
-    controllableEstuaryWidget pageId ctxVar renderInfoVar protocol
+    estuaryWidget pageId ctxVar renderInfoVar protocol
 
 silentEstuary :: EstuaryProtocolObject -> IO ()
-silentEstuary protocol = do
-  ic <- initCtx
-  c <- newMVar $ ic
-  ri <- newMVar $ emptyRenderInfo
-  forkRenderThread c ri
-
-  renderSync_ $ estuaryWidget c ri protocol
+silentEstuary protocol = silentEstuaryWithInitialPage protocol Splash
 
 initCtx :: IO Context
 initCtx = do

--- a/client/test/Interaction.hs
+++ b/client/test/Interaction.hs
@@ -35,7 +35,7 @@ import Estuary.Types.EnsembleResponse
 
 import Estuary.Test.Protocol
 import Estuary.Test.Estuary
-import Estuary.Test.Dom
+import qualified Estuary.Test.Dom as DomUtils
 
 import Estuary.Widgets.Navigation
 
@@ -68,12 +68,12 @@ main = hspec $ do
       -- expected layout.
       threadDelay $ 1000 * 1000
 
-      Just (editor :: Element) <- findMatchingSelectorInDocument ".estuary .page .eightMiddleL .textPatternChain:nth-child(2)"
-      Just (evalBtn :: HTMLElement) <- findMatchingSelector editor "button"
-      Just (txtArea :: HTMLTextAreaElement) <- findMatchingSelector editor "textarea"
+      Just (editor :: Element) <- DomUtils.findMatchingSelectorInDocument ".estuary .page .eightMiddleL .textPatternChain:nth-child(2)"
+      Just (evalBtn :: HTMLElement) <- DomUtils.findMatchingSelector editor "button"
+      Just (txtArea :: HTMLTextAreaElement) <- DomUtils.findMatchingSelector editor "textarea"
 
-      HTMLTextAreaElement.setValue txtArea $ Just "s \"bd\""
-      HTMLElement.click evalBtn
+      DomUtils.changeValue txtArea "s \"bd\""
+      DomUtils.click evalBtn
 
       return (reqStream, respStream)
 

--- a/client/test/Interaction.hs
+++ b/client/test/Interaction.hs
@@ -64,8 +64,8 @@ main = hspec $ do
           EnsembleResponse (Sited "abc" (DefaultView view)) -> Matches
           _ -> DoesNotMatch
 
-      The editors should not take more that 1s to appear after receiving the
-      expected layout.
+      -- The editors should not take more that 1s to appear after receiving the
+      -- expected layout.
       threadDelay $ 1000 * 1000
 
       Just (editor :: Element) <- findMatchingSelectorInDocument ".estuary .page .eightMiddleL .textPatternChain:nth-child(2)"


### PR DESCRIPTION
The tests use the actual estuary widgets now and moving the specification of the start page up to the estuary widget is the reason why. This also prevents resuming where you left off when refreshing the page (it always goes back to the splash on reload). 

The sample names are now stored in the `Context` in a newtype `SampleMap` which is just a `Map String (Seq String)` that needed to be wrapped in a newtype so that a `JSON` instance could be provided for it that doesn't conflict with the existing one for `Map`. The function `unSampleMap :: SampleMap -> Map String (Seq String)` will unwrap the newtype (@luisnavarrodelangel).