### PR TITLE
Small style fixes and smarter definition map reuse

### DIFF
--- a/client/src/Estuary/Types/Context.hs
+++ b/client/src/Estuary/Types/Context.hs
@@ -20,6 +20,7 @@ data Context = Context {
   language :: Language,
   theme :: String,
   tempo :: Tempo,
+  activeDefsEnsemble :: String, -- ^ The name of the ensemble in which the current definitions in the context belong to.
   definitions :: DefinitionMap,
   samples :: SampleMap,
   webDirtOn :: Bool,
@@ -38,6 +39,7 @@ initialContext now wd sd mv = Context {
   language = English,
   theme = "../css-custom/classic.css",
   tempo = Tempo { cps = 0.5, at = now, beat = 0.0 },
+  activeDefsEnsemble = "",
   definitions = empty,
   samples = emptySampleMap,
   webDirtOn = True,
@@ -66,8 +68,11 @@ setRmsLevels xs c = c { rmsLevels = xs }
 setClientCount :: Int -> ContextChange
 setClientCount x c = c { clientCount = x }
 
-setDefinitions :: DefinitionMap -> ContextChange
-setDefinitions x c = c { definitions = x }
+setDefinitions :: (String, DefinitionMap) -> ContextChange
+setDefinitions (x, y) c = c { 
+  activeDefsEnsemble = x, 
+  definitions = y 
+}
 
 setSampleMap :: SampleMap -> ContextChange
 setSampleMap x c = c { samples = x}

--- a/client/src/Estuary/Types/EnsembleState.hs
+++ b/client/src/Estuary/Types/EnsembleState.hs
@@ -28,6 +28,9 @@ data EnsembleState = EnsembleState {
   tempo :: Tempo
 }
 
+soloEnsembleName :: String
+soloEnsembleName = ""
+
 commandToHint :: EnsembleState -> Terminal.Command -> Maybe Hint
 commandToHint es (Terminal.DumpView) = Just $ LogMessage $ dumpView (currentView es)
 commandToHint _ _ = Nothing

--- a/common/src/Estuary/Types/Definition.hs
+++ b/common/src/Estuary/Types/Definition.hs
@@ -22,6 +22,9 @@ data Definition =
 
 type DefinitionMap = IntMap.IntMap Definition
 
+emptyDefinitionMap :: DefinitionMap
+emptyDefinitionMap = IntMap.empty
+
 instance JSON Definition where
   showJSON = toJSON
   readJSON = fromJSON

--- a/static/css-source/source.css
+++ b/static/css-source/source.css
@@ -63,6 +63,12 @@
 	padding-right: 15px;
 	margin-top: 0.5em;
   font-family: estuaryFont;
+  
+  /* Force the browser to try it's best to float properly on overflow. 
+     When the window doesn't fit the entire header, this ensures that moving
+     the controls to the next line doesn't leak out of it's parent container
+     preventing interation with it. */
+  overflow: hidden; 
 }
 
 /* source  */

--- a/static/css-source/source.css
+++ b/static/css-source/source.css
@@ -234,6 +234,10 @@
 		display: flex;
 		width: 100%;
 		height: 100%;
+
+		max-width: 16em; /* Taken from .splash-panel */
+		margin: auto; /* centered */
+		min-height: 0; /* Fixes flex stretching for underspecified boxes to be the flex'd height rather than parent height. */
 }
 
 .splash-icon {
@@ -245,6 +249,10 @@
 .splash-icon > canvas {
     max-width: 100%;
     max-height: 100%;
+
+    /* only clicking the icon when it is in place (over the panel) should 
+       trigger the event for the panel, not during the animation. */
+    pointer-events: none; 
   }
 
 /*contains the container of the about text  (source)*/


### PR DESCRIPTION
Fixes the issue where the webdirt (and other) controls were not interact-able when the window gets too small and the controls floated out of the div (like when dev tools are open).

Fixes the size of the panel icons to a max of `16em` to prevent inheriting the 800px size of the canvas on firefox.

The context now tracks which ensemble the active definitions belong to. This allows only using them as a default if rejoining the same ensemble that was last left. Fixes an issue where going (for example) from a collaborate ensemble to the solo ensemble copied the definitions for any views with common ids into the solo space.