### PR TITLE
Testing infrastructure update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ installInteractionTestClient:
 	$(STACK_CLIENT) build estuary:exe:interaction-test --flag estuary:build-test-executables
 	$(CP_RECURSIVE) $$($(STACK_CLIENT) path --local-install-root)/bin/interaction-test.jsexe/* Estuary.jsexe
 	$(CP_RECURSIVE) static/* Estuary.jsexe
-	$(CLIENT_GCC_PREPROCESSOR) ../Estuary.jsexe/index.html.template -o ../Estuary.jsexe/index.html
+	$(CLIENT_GCC_PREPROCESSOR) ../Estuary.jsexe/index.html.template -DTEST -o ../Estuary.jsexe/index.html
 
 installServer: buildServer
 	mkdir -p EstuaryServer

--- a/client/package.yaml
+++ b/client/package.yaml
@@ -74,6 +74,12 @@ executables:
       - ./app
     dependencies:
       - estuary
+    when:
+    - condition: flag(build-test-executables)
+      then:
+        buildable: false
+      else:
+        buildable: true
 
   simple-test:
     <<: *test-executable
@@ -82,6 +88,7 @@ executables:
       - ./test
     dependencies:
       - estuary
+      - bytestring-handle
       - hspec
       - async
 
@@ -95,6 +102,7 @@ executables:
     dependencies:
       - estuary
       - estuary-common
+      - bytestring-handle
       - hspec
       - async
 

--- a/client/stack.yaml
+++ b/client/stack.yaml
@@ -59,3 +59,12 @@ extra-deps:
   - monoidal-containers-0.4.0.0
   - hosc-0.16
   - parsec-numbers-0.1.0
+
+  # hspec and hspec-2.2.4 dependencies. Newer version may or may not work in GHCJS
+  - hspec-2.2.4
+  - hspec-core-2.2.4
+  - hspec-expectations-0.7.2
+  - hspec-discover-2.2.4
+  - HUnit-1.3.1.2
+  - QuickCheck-2.8.2
+  - quickcheck-io-0.1.4

--- a/client/test/Estuary/Test/Dom.hs
+++ b/client/test/Estuary/Test/Dom.hs
@@ -42,12 +42,18 @@ findAllMatchingSelector container query =
 click :: (IsHTMLElement e) => e -> IO ()
 click = HTMLElement.click
 
-changeValue :: (IsGObject e, ToJSString val) => e -> val -> IO ()
+innerText :: (IsHTMLElement e, FromJSString s) => e -> IO (s)
+innerText = HTMLElement.getInnerText
+
+-- Like textContent but only for immediate children of the input element
+immediateText :: (IsElement e, FromJSString s) => e -> IO (s)
+immediateText el = fromJSString <$> js_immediateText (pToJSVal $ toElement el)
+
+changeValue :: (IsHTMLElement e, ToJSString val) => e -> val -> IO ()
 changeValue e value = do
-  let e' = uncheckedCastTo HTMLInputElement $ e
-      
-  HTMLInputElement.setValue e' value
-  notifyChanged e'
+  js_setValue (pToJSVal $ toElement e) (toJSString value)
+  notifyChanged e
+
 
 notifyChanged :: (IsEventTarget e) => e -> IO ()
 notifyChanged e = js_dispatchInputEvent (pToJSVal $ toEventTarget e)
@@ -55,6 +61,10 @@ notifyChanged e = js_dispatchInputEvent (pToJSVal $ toEventTarget e)
 ------------------------------------------
 -- JS FFI
 ------------------------------------------
+
+foreign import javascript safe
+  "$1.value = $2;"
+  js_setValue :: JSVal -> JSString -> IO ()
 
 foreign import javascript safe
   "document.querySelector($1)"
@@ -73,5 +83,12 @@ foreign import javascript safe
   js_querySelectorAll :: JSVal -> JSString -> IO (JSVal)
 
 foreign import javascript safe
-  "$1.dispatchEvent(new Event('input'))"
+  "$1.dispatchEvent(new Event('input', {bubbles: true, cancelable: true}))"
   js_dispatchInputEvent :: JSVal -> IO ()
+
+foreign import javascript safe
+  "$r = Array.from($1.childNodes)\
+  \.filter(function (n) { return n.nodeType === 3; })\
+  \.map(function (n) { return n.nodeValue; })\
+  \.join('');"
+  js_immediateText :: JSVal -> IO (JSString)

--- a/client/test/Estuary/Test/Dom.hs
+++ b/client/test/Estuary/Test/Dom.hs
@@ -42,12 +42,11 @@ findAllMatchingSelector container query =
 click :: (IsHTMLElement e) => e -> IO ()
 click = HTMLElement.click
 
-changeValue :: (IsGObject e) => e -> String -> IO ()
+changeValue :: (IsGObject e, ToJSString val) => e -> val -> IO ()
 changeValue e value = do
-  let e' :: HTMLInputElement
-      e' = unsafeCastGObject $ toGObject e
+  let e' = uncheckedCastTo HTMLInputElement $ e
       
-  HTMLInputElement.setValue e' (Just value)
+  HTMLInputElement.setValue e' value
   notifyChanged e'
 
 notifyChanged :: (IsEventTarget e) => e -> IO ()

--- a/client/test/Estuary/Test/Estuary.hs
+++ b/client/test/Estuary/Test/Estuary.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE RecursiveDo #-}
 module Estuary.Test.Estuary where
-{- BROKEN -}
+
 import Reflex.Dom
 import Data.Time
 
@@ -21,6 +21,7 @@ import Estuary.Widgets.WebSocket
 
 import Estuary.Types.Request
 import Estuary.Types.Response
+import Estuary.Types.CanvasState
 import Estuary.Types.Context
 import Estuary.Types.Hint
 import Estuary.Types.View
@@ -34,6 +35,8 @@ import Estuary.RenderState
 import Estuary.Renderer
 
 import Estuary.Test.Reflex
+
+import Sound.MusicW
 
 silentEstuaryWithInitialPage :: EstuaryProtocolObject -> Navigation -> IO ()
 silentEstuaryWithInitialPage protocol pageId = do
@@ -52,10 +55,13 @@ silentEstuary protocol = silentEstuaryWithInitialPage protocol Splash
 initCtx :: IO Context
 initCtx = do
   now <- Data.Time.getCurrentTime
-  mv <- newMVar []
-  let ctx = initialContext now js_nullWebDirt js_nullSuperDirt mv
+  bus <- liftAudioIO $ createDestination 
+  canvasState <- emptyCanvasState >>= newMVar
+  let ctx = initialContext now bus js_nullWebDirt js_nullSuperDirt canvasState
   return $ ctx {
-    webDirtOn = False
+    webDirtOn = False,
+    superDirtOn = False,
+    canvasOn = False
   }
 
 foreign import javascript safe

--- a/client/test/Estuary/Test/Protocol.hs
+++ b/client/test/Estuary/Test/Protocol.hs
@@ -118,7 +118,7 @@ performRequest protocol = send protocol . encode
 
 attachMsgRecvProtocolInspector :: EstuaryProtocolObject -> (Maybe Response -> IO ()) -> IO ()
 attachMsgRecvProtocolInspector (EstuaryProtocolObject protocol) inspect = do
-  cb <- asyncCallback1 $ \nJsSerResp ->
+  cb <- asyncCallback1 $ \nJsSerResp -> do
     inspect $ do -- in Maybe 
       jsSerResp <- mfilter (not . isNull) (pure nJsSerResp)
       serResp <- pFromJSVal jsSerResp
@@ -130,7 +130,7 @@ attachMsgRecvProtocolInspector (EstuaryProtocolObject protocol) inspect = do
 
 attachSendMsgProtocolInspector :: EstuaryProtocolObject -> (Maybe Request -> IO ()) -> IO ()
 attachSendMsgProtocolInspector (EstuaryProtocolObject protocol) inspect = do
-  cb <- asyncCallback1 $ \nJsSerReq -> 
+  cb <- asyncCallback1 $ \nJsSerReq -> do
     inspect $ do -- in Maybe 
       jsSerReq <- mfilter (not . isNull) (pure nJsSerReq)
       serResp <- pFromJSVal jsSerReq

--- a/client/test/Estuary/Test/Protocol.hs
+++ b/client/test/Estuary/Test/Protocol.hs
@@ -21,7 +21,6 @@ import Estuary.Types.Sited
 import Estuary.Types.EnsembleRequest
 import Estuary.Types.EnsembleResponse
 
-import GHCJS.DOM.Types
 import GHCJS.Marshal
 import GHCJS.Marshal.Pure
 import GHCJS.Types

--- a/client/test/Estuary/Test/Reflex.hs
+++ b/client/test/Estuary/Test/Reflex.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeFamilies, RankNTypes, OverloadedStrings #-}
 module Estuary.Test.Reflex where
 
 import Control.Concurrent.MVar
@@ -6,19 +6,15 @@ import Control.Concurrent.Async
 import Control.Monad.IO.Class
 
 import Data.Map
-
-import GHCJS.DOM.Types (Element, HTMLDivElement, castToHTMLDivElement, fromJSString)
+import GHCJS.DOM.Types (Element, HTMLDivElement(..), uncheckedCastTo, fromJSString)
 
 import Reflex.Dom hiding (link)
 import Reflex.Dynamic
 import Reflex.Host.Class (HostFrame)
 
--- The type of widget that `mainWidget` can render.
-type SpiderM = Widget Spider (Gui Spider (WithWebView SpiderHost) (HostFrame Spider))
-
 -- renderSync renders the widget, waits for it to mount, and returns the container
 -- element it was mounted in.
-renderSync :: (MonadWidget t m, m ~ SpiderM) => m a -> IO (HTMLDivElement)
+renderSync :: (forall x. Widget x ()) -> IO (HTMLDivElement)
 renderSync widget = do
   resultContainer <- newEmptyMVar
   finishedRender <- async $ takeMVar resultContainer
@@ -27,7 +23,7 @@ renderSync widget = do
   mainWidget $ do
     (e, _) <- elAttr' "div" (fromList [("id", "test-container")]) widget
 
-    let containerEl = castToHTMLDivElement $ _el_element e
+    let containerEl = uncheckedCastTo HTMLDivElement $ _element_raw e
     postBuildEv <- getPostBuild
     performEvent_ $ ffor postBuildEv $ \_ -> liftIO $
       putMVar resultContainer containerEl
@@ -35,23 +31,8 @@ renderSync widget = do
   wait finishedRender
 
 -- renderSync_ renders the widget and waits for it to mount.
-renderSync_ :: (MonadWidget t m, m ~ SpiderM) => m a -> IO ()
+renderSync_ :: (forall x. Widget x ()) -> IO ()
 renderSync_ widget = do
-  resultContainer <- newEmptyMVar
-  finishedRender <- async $ takeMVar resultContainer
-  link finishedRender -- any exceptions should be thrown here
-
-  mainWidget $ do
-    elAttr' "div" (fromList [("id", "test-container")]) widget
-
-    postBuildEv <- getPostBuild
-    performEvent_ $ ffor postBuildEv $ \_ -> liftIO $
-      putMVar resultContainer ()
-
-  wait finishedRender
-
-renderSyncWithEvent :: (MonadWidget t m, m ~ SpiderM) => m a -> IO ()
-renderSyncWithEvent widget = do
   resultContainer <- newEmptyMVar
   finishedRender <- async $ takeMVar resultContainer
   link finishedRender -- any exceptions should be thrown here

--- a/client/test/Estuary/Test/Util.hs
+++ b/client/test/Estuary/Test/Util.hs
@@ -1,0 +1,18 @@
+module Estuary.Test.Util where
+
+import Control.Concurrent
+import Control.Exception
+
+tryUntilTimeout :: (Real interval) => interval -> Int -> IO a -> IO a
+tryUntilTimeout wait attempts action = go (max (1::Int) attempts)
+  where 
+    go attemptsLeft = do
+      result <- try action
+      case result of
+        Left e -> 
+          if attemptsLeft > 1 then do
+            threadDelay $ (ceiling (toRational wait * 1000) :: Int)
+            go (attemptsLeft - 1)
+          else
+            throwIO (e :: SomeException)
+        Right a -> return a

--- a/client/test/Harness.hs
+++ b/client/test/Harness.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE DeriveGeneric, DeriveAnyClass #-}
+module Harness where
+
+import Data.ByteString
+import Data.ByteString.Handle
+
+import Test.Hspec
+import Test.Hspec.Runner
+
+import GHC.Generics
+
+import GHCJS.Types
+import GHCJS.Marshal
+import GHCJS.Marshal.Pure
+
+import qualified Data.ByteString.Lazy.Char8 as C8
+
+data TestResults = TestResults {
+  report :: String,
+  success :: Bool
+} deriving (Generic, FromJSVal, ToJSVal)
+
+hspecInHarness :: Spec -> IO ()
+hspecInHarness spec = do
+  inHarness <- isInHarness
+  if inHarness then do
+    results <- capturedHspec spec
+    putResults results
+  else do
+    hspec spec
+
+capturedHspec :: Spec -> IO TestResults
+capturedHspec spec = do
+  (output, summary) <- writeHandle False $ \h -> do
+    (flip hspecWithResult) spec defaultConfig {
+        configOutputFile = Left h,
+        configColorMode = ColorAlways
+      }
+
+  return $ TestResults {
+    report = C8.unpack output,
+    success = summaryFailures summary == 0
+  }
+
+putResults :: TestResults -> IO ()
+putResults results = do
+  val <- toJSVal results
+  js_putResults val
+
+foreign import javascript unsafe
+  "Boolean(window['ESTUARY_TEST_HARNESS_ENABLED'])"
+  isInHarness :: IO Bool
+
+foreign import javascript unsafe
+  "window['ESTUARY_TEST_HARNESS_RESULTS_CB']($1)"
+  js_putResults :: JSVal -> IO ()

--- a/client/test/Simple.hs
+++ b/client/test/Simple.hs
@@ -8,7 +8,7 @@ import Data.Map
 import Data.Maybe
 import Data.Time
 
-import GHCJS.DOM.Types(Element, IsHTMLElement, castToHTMLElement, fromJSString)
+import GHCJS.DOM.Types(IsHTMLElement, fromJSString)
 import GHCJS.DOM.HTMLElement(getInnerText)
 
 import Estuary.RenderInfo
@@ -19,6 +19,7 @@ import Estuary.Widgets.Estuary(header)
 
 import Estuary.Test.Reflex(renderSync)
 import Estuary.Test.Dom
+import Estuary.Test.Estuary
 
 import Reflex.Dom hiding (link)
 import Reflex.Dynamic
@@ -31,27 +32,18 @@ main = do
     describe "header" $ do
       it "changes the header when the language changes" $ do
         ctx <- initCtx
-        let dynCtx = constDyn ctx
-        let dynRenferInfo = constDyn emptyRenderInfo
-        let widget = header dynCtx dynRenferInfo
-
-        h <- renderSync widget
+        h <- renderSync $ do
+          let dynCtx = constDyn ctx
+          let dynRenferInfo = constDyn emptyRenderInfo
+          header dynCtx dynRenferInfo
+          return ()
         text <- elInnerText h
         text `shouldStartWith` "BLAH"
-
-initCtx :: IO Context
-initCtx = do
-  now <- Data.Time.getCurrentTime
-  mv <- newMVar []
-  let ctx = initialContext now nullWebDirt nullSuperDirt mv
-  return $ ctx {
-    webDirtOn = False
-  }
 
 elInnerText :: (IsHTMLElement e) => e -> IO (String)
 elInnerText el = do
   mTextJs <- getInnerText $ el
-  return $ maybe "" id mTextJs
+  return mTextJs
 
 foreign import javascript safe
   "null"

--- a/client/test/harness/index.js
+++ b/client/test/harness/index.js
@@ -3,7 +3,23 @@ const puppeteer = require('puppeteer');
 ;(async () => {
   const browser = await puppeteer.launch({args: ['--no-sandbox']});
   const page = await browser.newPage();
-  await page.goto('http://google.com');
+
+  await page.evaluateOnNewDocument(() => window['ESTUARY_TEST_HARNESS_ENABLED'] = true);
+  await page.evaluateOnNewDocument(() => {
+    window['ESTUARY_TEST_HARNESS_RESULTS'] = new Promise((resolve, reject) => {
+      window['ESTUARY_TEST_HARNESS_RESULTS_CB'] = resolve;
+    });
+  });
+
+  const url = 'http://localhost:8002';
+  console.log(`Visiting ${url}...`);
+  page.on('console', msg => console.log(`${url} ${msg.type().toUpperCase()}: ${msg.text()}`));
+
+  await page.goto(url);
+
+  const results = await page.evaluate(async () => await window['ESTUARY_TEST_HARNESS_RESULTS']);
+  console.log('TEST RESULTS - ', results.success ? 'SUCCESS' : 'FAILURE');
+  console.log(results.report);
 
   const performanceTiming = JSON.parse(
     await page.evaluate(() => JSON.stringify(window.performance.timing))

--- a/client/test/harness/index.js
+++ b/client/test/harness/index.js
@@ -4,8 +4,8 @@ const puppeteer = require('puppeteer');
   const browser = await puppeteer.launch({args: ['--no-sandbox']});
   const page = await browser.newPage();
 
-  await page.evaluateOnNewDocument(() => window['ESTUARY_TEST_HARNESS_ENABLED'] = true);
   await page.evaluateOnNewDocument(() => {
+    window['ESTUARY_TEST_HARNESS_ENABLED'] = true
     window['ESTUARY_TEST_HARNESS_RESULTS'] = new Promise((resolve, reject) => {
       window['ESTUARY_TEST_HARNESS_RESULTS_CB'] = resolve;
     });
@@ -24,7 +24,8 @@ const puppeteer = require('puppeteer');
   const performanceTiming = JSON.parse(
     await page.evaluate(() => JSON.stringify(window.performance.timing))
   );
-  console.log(performanceTiming);
+  //console.log(performanceTiming);
 
   await browser.close();
+  process.exitCode = results.success ? 0 : 1;
 })();

--- a/static/index.html.template
+++ b/static/index.html.template
@@ -5,33 +5,22 @@
   <link defer href="../css-source/source.css" rel="stylesheet" type="text/css"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-#ifndef PRODUCTION
-  <script defer language="javascript" src="rts.js"></script>
-  <script defer language="javascript" src="lib.js"></script>
-  <script defer language="javascript" src="out.js"></script>
-#endif
-  <script defer language="javascript" src="EstuaryProtocol.js"></script>
-  <script defer language="javascript" src="SuperDirt.js"></script>
-  <script defer language="javascript" src="WebDirt/WebDirt.js"></script>
-  <script defer language="javascript" src="WebDirt/Graph.js"></script>
-  <script defer language="javascript" src="WebDirt/SampleBank.js"></script>
-  <script defer language="javascript">
-function downloadJS() {
-  var element4 = document.createElement("script");
-#ifdef PRODUCTION
-  element4.setAttribute('src', "all.min.js");
-#else
-  element4.setAttribute('src', "runmain.js");
-#endif
-  element4.defer;
-  document.head.appendChild(element4);
-  console.log("elements added");
-}
+  <script defer type="text/javascript" src="EstuaryProtocol.js"></script>
+  <script defer type="text/javascript" src="SuperDirt.js"></script>
+  <script defer type="text/javascript" src="WebDirt/WebDirt.js"></script>
+  <script defer type="text/javascript" src="WebDirt/Graph.js"></script>
+  <script defer type="text/javascript" src="WebDirt/SampleBank.js"></script>
 
-function start(){
-  downloadJS();
-}
-  </script>
+#ifdef PRODUCTION
+  <script defer type="text/javascript" src="all.min.js"></script>
+#else
+  <script defer type="text/javascript" src="rts.js"></script>
+  <script defer type="text/javascript" src="lib.js"></script>
+  <script defer type="text/javascript" src="out.js"></script>
+  <script defer type="text/javascript" src="runmain.js"></script>
+#endif
+
+#ifndef TEST
   <style type="text/css">
     .full-screen {
       position: fixed;
@@ -65,9 +54,11 @@ function start(){
     }
   </style>
   <script type="text/javascript" src="estuary-icon.js"></script>
+#endif
 </head>
-<body onload="start()">
+<body>
   <div id="estuary-root"></div>
+#ifndef TEST
   <div id="estuary-splash" class="estuary-logo full-screen"></div>
   <script type="text/javascript">
     var EstuaryIcon = (function() {
@@ -88,5 +79,6 @@ function start(){
       };
     })();
   </script>
+#endif
 </body>
 </html>


### PR DESCRIPTION
*   Update test utils for the newer reflex version. 
    *   main widget is mounted with `mainWidgetInElementById "estuary-root"`.
    *    revert to `hspec-2.2.4` as the version in this snapshot (`2.4.4`) doesn't seem to work well in GHCJS.
*   Support running the tests in puppeteer.
    *  if the global variable `ESTUARY_TEST_HARNESS_ENABLED` is truthy, test results will be captured and passed to the global function `ESTUARY_TEST_HARNESS_RESULTS_CB`.
    *   if the results are successful, puppeteer will exit with a code `0`, otherwise `1`. It will also print the results.
    *   there is a `TEST` variant for the `index.html.template` which sets up the main page for running in the harness mode (no icon at the start).
*   Add a test that checks that the `!` appears after evaluating bad code in a minitidal text widget.

To run the tests:
1.  Have a `Estuary.db` with an ensemble named `abc` with password `abc` with the default view. (Still working out a better way to declare this setup for running the tests).
2.  Run `make installInteractionTestClient` to build and install the client for running the interaction tests.
3.  Start the server with `./EstuaryServer/EstuaryServer`
4.  In a different terminal (the server still needs to be running), in the folder `./client/test/harness` run `node index.js`. (If there is an error finding the package make sure you have run `yarn install` at least once to download the required modules.)
